### PR TITLE
Fix markup error exclusive to 500.md

### DIFF
--- a/content/500.md
+++ b/content/500.md
@@ -9,4 +9,4 @@ This error response is a generic "catch-all" response. Usually, this indicates t
 - [Spec](https://www.rfc-editor.org/rfc/rfc9110#status.500)
 - [500 Internal Server Error](https://http.cat/status/500)
 
-**Source: **[https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500)
+**Source:** [https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500)


### PR DESCRIPTION
`**Source:** ` is bold text, `**Source: **` is not. This issue can only be found in this one file, according to a poorly constructed `grep`. 