### PR TITLE
feat: add ID to each thumbnail

### DIFF
--- a/components/Thumbnail/Thumbnail.tsx
+++ b/components/Thumbnail/Thumbnail.tsx
@@ -11,7 +11,7 @@ const Thumbnail = ({ code, description, t }: ThumbnailProps) => {
   const hrefBase = t.LOCALE === 'ca' ? '/ca' : '';
 
   return (
-    <div className="flex flex-col flex-grow h-full text-white overflow-hidden rounded shadow bg-[--interactive]">
+    <div id={`${code}`} className="flex flex-col flex-grow h-full text-white overflow-hidden rounded shadow bg-[--interactive]">
       <Link
         href={`${hrefBase}/status/${code}`}
         className="text-white no-underline"


### PR DESCRIPTION
By adding an ID to each thumbnail, users will be able to scroll to a specific status code via http.cat#301 - scrolling to the correct item while still being able to browse the other codes.

A question I ask myself frequently is whether I want to use 301 or 307 redirects. Previously, I'd go to http.cat/301, realise it's not the right one, edit the URL bar and go back to 307.

But by adding the anchor to the URL bar the browser will scroll me to the correct entry and I can see, without leaving the current page.