### PR TITLE
fix(status-page): remember scroll position when navigating home

### DIFF
--- a/app/ca/page.tsx
+++ b/app/ca/page.tsx
@@ -3,6 +3,7 @@ import ThumbnailGrid from '@/components/ThumbnailGrid';
 import Thumbnail from '@/components/Thumbnail';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
+import ScrollRestore from '@/components/ScrollRestore';
 import { getTranslations } from '@/lib/translation';
 
 import statuses from '@/lib/statuses';
@@ -12,6 +13,7 @@ export default async function Home() {
 
   return (
     <>
+      <ScrollRestore />
       <Header t={t} />
       <main>
         <Usage t={t} />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@ import ThumbnailGrid from '@/components/ThumbnailGrid';
 import Thumbnail from '@/components/Thumbnail';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
+import ScrollRestore from '@/components/ScrollRestore';
 import { getTranslations } from '@/lib/translation';
 
 import statuses from '@/lib/statuses';
@@ -12,6 +13,7 @@ export default async function Home() {
 
   return (
     <>
+      <ScrollRestore />
       <Header t={t} />
       <main>
         <Usage t={t} />

--- a/app/status/[status]/page.tsx
+++ b/app/status/[status]/page.tsx
@@ -21,7 +21,11 @@ export default async function Info({ params }: { params: { status: string } }) {
       <Header t={t} />
       <main>
         <nav>
-          <Link href="/" className="text-white">{`< ${t.BACK_TO_HOME}`}</Link>
+          <Link
+            href="/"
+            className="text-white"
+            scroll={false}
+          >{`< ${t.BACK_TO_HOME}`}</Link>
         </nav>
 
         <h1 className="text-center my-12">

--- a/components/ScrollRestore/ScrollRestore.tsx
+++ b/components/ScrollRestore/ScrollRestore.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { useEffect } from 'react';
+
+const ScrollRestore = () => {
+  useEffect(() => {
+    const savedPosition = sessionStorage.getItem('homeScrollPosition');
+    if (savedPosition) {
+      window.scrollTo(0, parseInt(savedPosition, 10));
+      sessionStorage.removeItem('homeScrollPosition');
+    }
+  }, []);
+
+  return null;
+};
+
+export default ScrollRestore;

--- a/components/ScrollRestore/index.ts
+++ b/components/ScrollRestore/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ScrollRestore';

--- a/components/Thumbnail/Thumbnail.tsx
+++ b/components/Thumbnail/Thumbnail.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Link from 'next/link';
 import Image from 'next/image';
 
@@ -10,10 +12,15 @@ type ThumbnailProps = {
 const Thumbnail = ({ code, description, t }: ThumbnailProps) => {
   const hrefBase = t.LOCALE === 'ca' ? '/ca' : '';
 
+  const saveScrollPosition = () => {
+    sessionStorage.setItem('homeScrollPosition', window.scrollY.toString());
+  };
+
   return (
     <div id={`${code}`} className="flex flex-col flex-grow h-full text-white overflow-hidden rounded shadow bg-[--interactive]">
       <Link
         href={`${hrefBase}/status/${code}`}
+        onClick={saveScrollPosition}
         className="text-white no-underline"
       >
         <div className="pt-[56.25%] relative overflow-hidden">


### PR DESCRIPTION
There were a couple of ways to address this:

1 - Using the browser's History API calling `back()`, which would get us the scroll position feature "for free", but would create weird use cases such as when the user lands on a status page coming from another website (ie. google.com) clicking the link "back to home" would take the user back to that other website

2 - Implement a scroll position restore feature using the `window.scrollTo` API and save the position when the origin link is clicked

Since the purpose of the "Back to Home" link is to take the user to the http cats homepage and not technically back in the browser history. I ended up choosing the second approach because it suites better the purpose of the link.

This implementation is prone to a race condition on slower devices where the `scrollTo` call can happen before the page rendering. The way to fix this would be to place the `scrollTo` call in a `setTimeout` so that its queued after the page rendering. The problem is that this introduced delay can be seen and makes the interaction look less fluid, so I removed the `setTimout` and measure the results in production first.

Closes #258 