### PR TITLE
Add /random endpoint to display a random http.cat image.

### DIFF
--- a/app/random/page.tsx
+++ b/app/random/page.tsx
@@ -1,10 +1,19 @@
-import { redirect } from 'next/navigation';
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 
 import statuses from '@/lib/statuses';
 
 export default function Random() {
-  const statusCodes = Object.keys(statuses);
-  const randomStatus = statusCodes[Math.floor(Math.random() * statusCodes.length)];
-  
-  redirect(`/status/${randomStatus}`);
+  const router = useRouter();
+
+  useEffect(() => {
+    const statusCodes = Object.keys(statuses);
+    const randomStatus = statusCodes[Math.floor(Math.random() * statusCodes.length)];
+
+    router.replace(`/status/${randomStatus}`);
+  }, [router]);
+
+  return null;
 }

--- a/app/random/page.tsx
+++ b/app/random/page.tsx
@@ -1,0 +1,10 @@
+import { redirect } from 'next/navigation';
+
+import statuses from '@/lib/statuses';
+
+export default function Random() {
+  const statusCodes = Object.keys(statuses);
+  const randomStatus = statusCodes[Math.floor(Math.random() * statusCodes.length)];
+  
+  redirect(`/status/${randomStatus}`);
+}


### PR DESCRIPTION
Fixes #255 

This is a basic implementation on the issue request #255, please let me know if this is implemented correctly according to the project's coding style and instructions.

If there's any request to modify it, maybe to the Components section, I can do that as well.

The way it works is the following:

Upon visiting [http.cat/random](http.cat/random), it triggers this code (aka `app/random/page.tsx`). It will pull the http dictionary data from `statuses.js` and do a Math.random() on it. This will pull a pseudo-random value which it will then redirect towards.

What do you think? Thanks :)